### PR TITLE
Fix duplicate discount test name

### DIFF
--- a/python/agents/customer-service/tests/unit/test_tools.py
+++ b/python/agents/customer-service/tests/unit/test_tools.py
@@ -49,7 +49,7 @@ def test_approve_discount():
     assert result == {"status": "ok"}
 
 
-def test_approve_discount():
+def test_approve_discount_rejected():
     result = approve_discount(
         discount_type="percentage", value=15.0, reason="Test large discount"
     )


### PR DESCRIPTION
## Summary
- rename the second `test_approve_discount` to `test_approve_discount_rejected`
- run pytest for `python/agents/customer-service/tests/unit`

## Testing
- `pytest python/agents/customer-service/tests/unit -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_685babd00b488330a706d80aed2f7613